### PR TITLE
feat: Add 'Refresh Data' button in the UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,11 @@
 
     <aside id="filter-panel">
         <h4>Filters</h4>
+        <div id="refresh-container">
+            <button id="refresh-data-btn">🔄 Refresh Data from Drive</button>
+            <span id="refresh-spinner" class="hidden">⏳</span>
+        </div>
+        <div id="notification-bar" class="hidden"></div>
         <div>
             <label for="filter-search" class="visually-hidden">Search by name</label>
             <input type="text" id="filter-search" placeholder="Search by name...">

--- a/server.py
+++ b/server.py
@@ -1,5 +1,7 @@
 import json
 import os
+import traceback
+import read_chats
 from flask import Flask, request, jsonify, send_from_directory
 
 # --- Configuration ---
@@ -88,6 +90,22 @@ def handle_all_tags():
             return jsonify({"status": "success"})
         return jsonify({"status": "error", "message": "Failed to save all tags"}), 500
 
+@app.route('/api/refresh-data', methods=['POST'])
+def handle_refresh():
+    """Runs the read_chats.py script to refresh data from Google Drive."""
+    print("--- Received request to refresh data from Google Drive. ---")
+    try:
+        read_chats.main()
+        print("--- Data refresh completed successfully. ---")
+        return jsonify({"status": "success", "message": "Data updated successfully"}), 200
+    except Exception as e:
+        error_details = traceback.format_exc()
+        print(f"--- ERROR during data refresh: {e} ---")
+        print(error_details)
+        return jsonify({
+            "status": "error",
+            "message": "An error occurred while fetching data from Google Drive."
+        }), 500
 
 if __name__ == '__main__':
     print("Server is running! Open http://127.0.0.1:5000 in your browser.")

--- a/style.css
+++ b/style.css
@@ -340,3 +340,74 @@ body, html {
     clip: rect(0, 0, 0, 0);
     border: 0;
 }
+
+#refresh-container {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid #ddd;
+}
+
+#refresh-data-btn {
+    flex-grow: 1;
+    padding: 8px 12px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    background-color: #e8f0fe;
+    border: 1px solid var(--primary-color);
+    color: var(--primary-color);
+    border-radius: var(--border-radius-sm);
+    transition: background-color 0.2s;
+}
+
+#refresh-data-btn:hover {
+    background-color: #d2e3fc;
+}
+
+#refresh-data-btn:disabled {
+    cursor: not-allowed;
+    background-color: var(--light-gray);
+    border-color: var(--medium-gray);
+    color: var(--text-color-light);
+}
+
+#refresh-spinner {
+    font-size: 20px;
+    animation: spin 1.5s linear infinite;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+#notification-bar {
+    padding: 10px;
+    margin-bottom: 10px;
+    border-radius: var(--border-radius-sm);
+    text-align: center;
+    font-weight: 500;
+    font-size: 14px;
+    display: none;
+}
+
+#notification-bar.success {
+    background-color: #dff0d8;
+    color: #3c763d;
+    border: 1px solid #d6e9c6;
+    display: block;
+}
+
+#notification-bar.error {
+    background-color: #f2dede;
+    color: #a94442;
+    border: 1px solid #ebccd1;
+    display: block;
+}
+
+.hidden {
+    display: none !important;
+}


### PR DESCRIPTION
Implements a feature allowing users to refresh chat data directly from the web interface by clicking a button.

- Adds a POST endpoint /api/refresh-data to the Flask server, which triggers the 
ead_chats.py script.
- Implements a 'Refresh Data' button, a loading spinner, and a notification system in the frontend.
- Refactors the initial data loading logic to be reusable for reloading the graph after a successful data fetch.

Closes #2